### PR TITLE
chore(deps): bump eslint-import-resolver-typescript to 3.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-config-prettier": "^8.8.0",
-        "eslint-import-resolver-typescript": "^3.5.4",
+        "eslint-import-resolver-typescript": "^3.5.5",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-prettier": "^4.2.1",
         "husky": "^8.0.3",
@@ -3883,13 +3883,14 @@
       }
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.4.tgz",
-      "integrity": "sha512-9xUpnedEmSfG57sN1UvWPiEhfJ8bPt0Wg2XysA7Mlc79iFGhmJtRUg9LxtkK81FhMUui0YuR2E8iUsVhePkh4A==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.5.tgz",
+      "integrity": "sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
         "get-tsconfig": "^4.5.0",
         "globby": "^13.1.3",
         "is-core-module": "^2.11.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-config-prettier": "^8.8.0",
-    "eslint-import-resolver-typescript": "^3.5.4",
+    "eslint-import-resolver-typescript": "^3.5.5",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
     "husky": "^8.0.3",


### PR DESCRIPTION
bumps eslint-import-resolver-typescript from 3.5.4 to 3.5.5

ref #95