### PR TITLE
fix(ESLint): remove requireConfigFile, include, exclude on base config

### DIFF
--- a/config/eslint/typescript/config-base.js
+++ b/config/eslint/typescript/config-base.js
@@ -12,11 +12,8 @@ module.exports = {
   extends: ['airbnb-base', 'airbnb-typescript/base', 'prettier'],
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    requireConfigFile: false,
     tsconfigRootDir: __dirname,
     extends: './tsconfig.eslint.json',
-    exclude: ['node_modules', 'yarn.lock', '.yarn/*'],
-    include: ['*.ts', '*.js'],
     project: ['./tsconfig.eslint.json'],
   },
   settings: {


### PR DESCRIPTION
Remove requireConfigFile, include, exclude on ESLint base config.

BREAKING CHANGE: Removed requireConfigFile, include, exclude on ESLint base config at the parserOptions.
ref #135