### PR TITLE
feat(eslint): remove parserOptions from typescript base config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,11 @@ const config = require('./config');
 
 const data = {
   ...config.eslint.typescript.base,
-  parserOptions: { ...config.eslint.typescript.base.parserOptions, tsconfigRootDir: __dirname },
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    extends: './tsconfig.eslint.json',
+    project: ['./tsconfig.eslint.json'],
+  },
 };
 
 module.exports = data;

--- a/config/eslint/typescript/config-base.js
+++ b/config/eslint/typescript/config-base.js
@@ -11,11 +11,6 @@ module.exports = {
   plugins: ['@typescript-eslint', 'import', 'prettier'],
   extends: ['airbnb-base', 'airbnb-typescript/base', 'prettier'],
   parser: '@typescript-eslint/parser',
-  parserOptions: {
-    tsconfigRootDir: __dirname,
-    extends: './tsconfig.eslint.json',
-    project: ['./tsconfig.eslint.json'],
-  },
   settings: {
     'import/resolver': {
       typescript: {},

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,5 @@
 {
+  "compilerOptions": { "noEmit": true },
   "exclude": [".yarn/*", "yarn.lock", "package-lock.json", "node_modules"],
   "include": ["**/*.ts", "**/*.tsx", "**/*.js", ".*.js"]
 }


### PR DESCRIPTION
The parserOptions removed from the eslint typescript base config. Must be now defined in the project.

BREAKING CHANGE: The parserOptions must not defined in the project eslint config. ref #140