### PR TITLE
chore(project): set GitHub release as draft

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -2,6 +2,10 @@ const config = require('./config');
 
 module.exports = {
   ...config.releaseIt.base,
+  github: {
+    ...config.releaseIt.base.github,
+    draft: true,
+  },
   hooks: {
     ...config.releaseIt.base.hooks,
     'before:release': 'npx prettier --write . && git add . --update',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/DJBlackEagle/shared-project-tools/blob/main/CONTRIBUTING.md
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: Release
```

## What is the current behavior?

Publishing the package to NPM, was executed directly. Because the GitHub release was set as release and the GitHub workflow was running direclty.

Issue Number: #238 

## What is the new behavior?

Now, the GitHub release, will be only as a draft. So that's this released, then the PR is finished.

## Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
