### PR TITLE
feat(release-it): change GitHub release draft from false to true

### DIFF
--- a/config/release-it/config-base.js
+++ b/config/release-it/config-base.js
@@ -43,7 +43,7 @@ module.exports = {
     releaseNotes: null,
     autoGenerate: true,
     preRelease: false,
-    draft: false,
+    draft: true,
     tokenRef: 'GITHUB_TOKEN',
     assets: null,
     host: null,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/DJBlackEagle/shared-project-tools/blob/main/CONTRIBUTING.md
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Before was always publish and created a GitHub release. Now it's default only as draft.

Issue Number: N/A

## What is the new behavior?

The GitHub Release is now always as a "draft".

## Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x". -->

```
[X] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
