### PR TITLE
feat(cli-git): add git pull command, before the check of gone branches is running

### DIFF
--- a/src/module/cli/git/functions/index.ts
+++ b/src/module/cli/git/functions/index.ts
@@ -2,3 +2,4 @@ export * from './createInstance';
 export * from './fetch';
 export * from './getBranchLocal';
 export * from './isBranchGone';
+export * from './pull';

--- a/src/module/cli/git/functions/pull.ts
+++ b/src/module/cli/git/functions/pull.ts
@@ -1,0 +1,23 @@
+/* eslint-disable no-console */
+import { SimpleGit } from 'simple-git';
+
+async function pull(gitClient: SimpleGit): Promise<boolean> {
+  if (!gitClient) {
+    console.log('Git client is null.');
+
+    return Promise.resolve(false);
+  }
+
+  try {
+    await gitClient.pull();
+
+    return await Promise.resolve(true);
+  } catch (err) {
+    console.error('Can not fetch branches.');
+    console.error(err);
+
+    return Promise.resolve(false);
+  }
+}
+
+export { pull };

--- a/src/module/cli/git/pruneGoneBranches.ts
+++ b/src/module/cli/git/pruneGoneBranches.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-await-in-loop */
 /* eslint-disable no-console */
 import { resources } from '../../../resources';
-import { createInstance, fetch, getBranchLocal, isBranchGone } from './functions';
+import { createInstance, fetch, getBranchLocal, isBranchGone, pull } from './functions';
 
 type PruneGoneBranchesOptions = {
   dryDrun: boolean;
@@ -23,7 +23,20 @@ async function pruneGoneBranches(param: PruneGoneBranchesOptions | null): Promis
     return false;
   }
 
-  await fetch(client);
+  const resultPull = await pull(client);
+  if (!resultPull) {
+    console.log('Git pull failed.'.red);
+
+    return false;
+  }
+
+  const resultFetch = await fetch(client);
+  if (!resultFetch) {
+    console.log('Git fetch failed.'.red);
+
+    return false;
+  }
+
   const localBranches = await getBranchLocal(client);
   if (!localBranches) {
     console.log('Get local branches failed.'.red);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/DJBlackEagle/shared-project-tools/blob/main/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

The "git pruneGoneBranches" cli command, fetch only git information. If the default branch is not up to date, then the delete of the gone branch would be fail.

Issue Number: N/A

## What is the new behavior?

Before the "git pruneGoneBranches" cli command, check which branch is gone. It would execute the "git pull" command.

## Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
