### PR TITLE
chore(repo): change dependabot interval from monthy to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     directory: '/'
     schedule:
       timezone: 'Europe/Berlin'
-      interval: 'monthly'
+      interval: 'weekly'
     assignees:
       - 'djblackeagle'
     commit-message:
@@ -25,7 +25,7 @@ updates:
     directory: '/'
     schedule:
       timezone: 'Europe/Berlin'
-      interval: 'monthly'
+      interval: 'weekly'
     assignees:
       - 'djblackeagle'
     commit-message:


### PR DESCRIPTION
change dependabot interval from monthy to weekly

close #420

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/DJBlackEagle/shared-project-tools/blob/main/CONTRIBUTING.md
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: dependabot
```

## What is the current behavior?

The interval of the update check by dependabot, was set to monthly.

Issue Number: N/A

## What is the new behavior?

The interval of the update check by dependabot, set now to weekly.

## Does this PR introduce a breaking change?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
